### PR TITLE
Add global fragment support to schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ Utilities for GraphQL
 * `JSON`
 * `JSONObject`: A valid JSON object (arrays and other json values are invalid), most of the times you'd want to use `JSONObject` instead of `JSON`
 
-
-`IntID`
-
 ## Functions
 ### `makeSchemaFromModules(modules, opts)`
 Create a graphQL schema from various modules. If the module is a folder, it'll automatically require it.

--- a/index.d.ts
+++ b/index.d.ts
@@ -220,7 +220,11 @@ declare module 'gqutils' {
 		resolverValidationOptions?: IResolverValidationOptions;
 	}
 
-	type fragments = {[fragmentName: string]: string};
+	type fragments = {[fragmentName: string]: {
+		name: string;
+		type: string;
+		fields: string;
+	}};
 
 	interface gqlSchemas {
 		schema: schemaMap;
@@ -340,6 +344,18 @@ declare module 'gqutils' {
 		requestOptions?: {headers?: {[key: string]: string}, cookies?: {[key: string]: string}};
 	}
 
+	class GqlEnum {
+		constructor(val: string);
+		toString(): string;
+	}
+
+	class GqlFragment<F extends fragments = {}> {
+		constructor(fragments: F, key: keyof F);
+		toString(): string;
+		getName(): string;
+		getDefinition(): string;
+	}
+
 	class Gql {
 		constructor(opts: apiInput | schemaConfigInput);
 
@@ -351,10 +367,14 @@ declare module 'gqutils' {
 		exec(query: string, opts?: execOptions): Promise<any>;
 		getAll(query: string, opts?: execOptions): Promise<any>;
 		get(query: string, opts: execOptions): Promise<any>;
-		fragment(fragmentName: string): string;
+		/**
+		 * **NOTE:** Works only if if schema config options are passed
+		 * This automatically picks up the fragment from the generated schema
+		 */
+		fragment(fragmentName: string): GqlFragment;
 
-		enum(val: string): string;
-		static enum(val: string): string;
+		enum(val: string): GqlEnum;
+		static enum(val: string): GqlEnum;
 
 		static toGqlArg(arg: any, opts?: string[] | {pick?: string[], curlyBrackets?: boolean, roundBrackets?: boolean}): string;
 		static tag(strings: string[], ...args: any[]): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -295,7 +295,7 @@ declare module 'gqutils' {
 	}
 
 	interface schemaConfigInput extends commonOptions {
-		validateGrqphql?: boolean;
+		validateGraphql?: boolean;
 		cache?: Cache;
 		/**
 		 * By default it uses `formatError` from `gqutils`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -283,6 +283,8 @@ declare module 'gqutils' {
 	}};
 	function humanizeError(field: string, error: any): {message: string};
 
+	function toGqlArg(arg: any, opts?: string[] | {pick?: string[], curlyBrackets?: boolean, roundBrackets?: boolean}): string;
+
 	interface connectionResolvers<M> {
 		nodes: () => Promise<M[]>,
 		edges: () => Promise<{cursor: string, node: M}[]>,
@@ -379,7 +381,7 @@ declare module 'gqutils' {
 		enum(val: string): GqlEnum;
 		static enum(val: string): GqlEnum;
 
-		static toGqlArg(arg: any, opts?: string[] | {pick?: string[], curlyBrackets?: boolean, roundBrackets?: boolean}): string;
+		static toGqlArg: typeof toGqlArg;
 		static tag(strings: TemplateStringsArray, ...args: any[]): string;
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -371,7 +371,7 @@ declare module 'gqutils' {
 		getAll(query: string, opts?: execOptions): Promise<any>;
 		get(query: string, opts: execOptions): Promise<any>;
 		/**
-		 * **NOTE:** Works only if if schema config options are passed
+		 * **NOTE:** Works only if schema config options are passed
 		 * This automatically picks up the fragment from the generated schema
 		 */
 		fragment(fragmentName: FragmentsType): GqlFragment;

--- a/index.d.ts
+++ b/index.d.ts
@@ -321,6 +321,11 @@ declare module 'gqutils' {
 	class Gql {
 		constructor(opts: apiInput | schemaConfigInput);
 
+		/** Will exist if schema config options are passed */
+		schema?: schemaMap;
+		/** Will exist if schema config options are passed */
+		pubsub?: PubSub;
+
 		exec(query: string, opts?: execOptions): Promise<any>;
 		getAll(query: string, opts?: execOptions): Promise<any>;
 		get(query: string, opts: execOptions): Promise<any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -212,6 +212,7 @@ declare module 'gqutils' {
 	type GQUtilsSchema = GQUtilsTypeSchema | GQUtilsInputSchema | GQUTilsUnionSchema | GQUtilsInterfaceSchema | GQUtilsEnumSchema | GQUtilsScalarSchema | GQUtilsScalarSchemaAlternate | GQUtilsQuerySchema | GQUtilsFragmentSchema;
 
 	interface commonOptions {
+		/** default is `default` */
 		defaultSchemaName?: string;
 		schema?: string[];
 		schemas?: string[];
@@ -323,6 +324,8 @@ declare module 'gqutils' {
 	interface schemaConfigInput extends commonOptions {
 		validateGraphql?: boolean;
 		cache?: Cache;
+		/** Default is defaultSchemaName value */
+		schemaName?: string;
 		/**
 		 * By default it uses `formatError` from `gqutils`.
 		 * @param error Error object
@@ -356,7 +359,7 @@ declare module 'gqutils' {
 		getDefinition(): string;
 	}
 
-	class Gql {
+	class Gql<FragmentsType = string> {
 		constructor(opts: apiInput | schemaConfigInput);
 
 		/** Will exist if schema config options are passed */
@@ -371,7 +374,7 @@ declare module 'gqutils' {
 		 * **NOTE:** Works only if if schema config options are passed
 		 * This automatically picks up the fragment from the generated schema
 		 */
-		fragment(fragmentName: string): GqlFragment;
+		fragment(fragmentName: FragmentsType): GqlFragment;
 
 		enum(val: string): GqlEnum;
 		static enum(val: string): GqlEnum;

--- a/index.d.ts
+++ b/index.d.ts
@@ -380,6 +380,6 @@ declare module 'gqutils' {
 		static enum(val: string): GqlEnum;
 
 		static toGqlArg(arg: any, opts?: string[] | {pick?: string[], curlyBrackets?: boolean, roundBrackets?: boolean}): string;
-		static tag(strings: string[], ...args: any[]): string;
+		static tag(strings: TemplateStringsArray, ...args: any[]): string;
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -221,18 +221,20 @@ declare module 'gqutils' {
 		resolverValidationOptions?: IResolverValidationOptions;
 	}
 
-	type fragments = {[fragmentName: string]: {
+	type GQUtilsFragment = {
 		name: string;
 		type: string;
 		fields: string;
-	}};
+	};
+
+	type GQUtilsFragmentMap = {[fragmentName: string]: GQUtilsFragment};
 
 	interface gqlSchemas {
 		schema: schemaMap;
 		schemas: schemaMap;
 		defaultSchema: GraphQLSchema;
 		pubsub: PubSub;
-		fragments: {[schemaName: string]: fragments};
+		fragments: {[schemaName: string]: GQUtilsFragmentMap};
 	}
 	type schemaMap = {[key: string]: GraphQLSchema};
 
@@ -354,8 +356,8 @@ declare module 'gqutils' {
 		toString(): string;
 	}
 
-	class GqlFragment<F extends fragments = {}> {
-		constructor(fragments: F, key: keyof F);
+	class GqlFragment {
+		constructor(fragment: GQUtilsFragment);
 		toString(): string;
 		getName(): string;
 		getDefinition(): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -297,8 +297,12 @@ declare module 'gqutils' {
 	interface schemaConfigInput extends commonOptions {
 		validateGrqphql?: boolean;
 		cache?: Cache;
-		/** By default it uses `formatError` from `gqutils`. */
-		formatError?: (error: Error) => any;
+		/**
+		 * By default it uses `formatError` from `gqutils`.
+		 * @param error Error object
+		 * @param context The context passed to exec
+		 */
+		formatError?: (error: Error, context: any) => any;
 	}
 
 	interface apiInput {

--- a/index.d.ts
+++ b/index.d.ts
@@ -190,7 +190,26 @@ declare module 'gqutils' {
 		args?: GQUtilsArgs;
 	}
 
-	type GQUtilsSchema = GQUtilsTypeSchema | GQUtilsInputSchema | GQUTilsUnionSchema | GQUtilsInterfaceSchema | GQUtilsEnumSchema | GQUtilsScalarSchema | GQUtilsScalarSchemaAlternate | GQUtilsQuerySchema;
+	type fragmentField = string | Array<string | fragmentFieldObj>
+
+	interface fragmentFieldObj {
+		name: string;
+		/** If you want to alias the field, like: `name: fullName` */
+		alias?: string;
+		/** args for field, will be passed to `Gql.toGqlArg` */
+		args?: {[arg: string]: any};
+		/** If field type is itself aan object type */
+		fields?: fragmentField;
+	}
+
+	interface GQUtilsFragmentSchema extends GQUtilsBaseSchema {
+		graphql: 'fragment';
+		/** On which type is this fragment supposed to be defined */
+		type: string;
+		fields: fragmentField;
+	}
+
+	type GQUtilsSchema = GQUtilsTypeSchema | GQUtilsInputSchema | GQUTilsUnionSchema | GQUtilsInterfaceSchema | GQUtilsEnumSchema | GQUtilsScalarSchema | GQUtilsScalarSchemaAlternate | GQUtilsQuerySchema | GQUtilsFragmentSchema;
 
 	interface commonOptions {
 		defaultSchemaName?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -220,14 +220,17 @@ declare module 'gqutils' {
 		resolverValidationOptions?: IResolverValidationOptions;
 	}
 
+	type fragments = {[fragmentName: string]: string};
+
 	interface gqlSchemas {
 		schema: schemaMap;
 		schemas: schemaMap;
 		defaultSchema: GraphQLSchema;
 		pubsub: PubSub;
+		fragments: {[schemaName: string]: fragments};
 	}
-
 	type schemaMap = {[key: string]: GraphQLSchema};
+
 	type gqlConfig = commonOptions & {
 		baseFolder?: string;
 		contextType?: string,
@@ -348,6 +351,7 @@ declare module 'gqutils' {
 		exec(query: string, opts?: execOptions): Promise<any>;
 		getAll(query: string, opts?: execOptions): Promise<any>;
 		get(query: string, opts: execOptions): Promise<any>;
+		fragment(fragmentName: string): string;
 
 		enum(val: string): string;
 		static enum(val: string): string;

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -154,7 +154,6 @@ class Gql {
 
 	async exec(query, {
 		context,
-		ctx,
 		cache: {key: cacheKey, ttl = ONE_DAY} = {},
 		variables = {},
 		requestOptions = {},
@@ -170,18 +169,18 @@ class Gql {
 
 		const result = this._api ?
 			await this._execApi(query, {variables, requestOptions}) :
-			await this._execGraphql(query, {context: context || ctx, variables});
+			await this._execGraphql(query, {context, variables});
 
 		if (cacheKey && this._cache) await this._cache.set(cacheKey, result, {ttl});
 		return result;
 	}
 
-	async getAll(query, opts) {
-		return this.exec(query, opts);
+	async getAll(query, ...args) {
+		return this.exec(query, ...args);
 	}
 
-	async get(query, opts) {
-		const result = await this.exec(query, opts);
+	async get(query, ...args) {
+		const result = await this.exec(query, ...args);
 		if (!result) return result;
 
 		const keys = Object.keys(result);

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -221,6 +221,7 @@ class Gql {
 
 	static tag(strings, ...args) {
 		let out = strings[0];
+		const fragments = {};
 		for (let i = 1; i < strings.length; i++) {
 			const arg = args[i - 1];
 			if (/(?::|\()\s*$/.test(strings[i - 1])) {
@@ -234,6 +235,9 @@ class Gql {
 				}
 				else if (arg instanceof GqlFragment) {
 					out += arg.toString();
+					if (fragments[arg.getName()] === undefined) {
+						fragments[arg.getName()] = arg.getDefinition();
+					}
 				}
 				else if (Array.isArray(arg)) {
 					out += arg.filter(Boolean).join(' ');
@@ -242,6 +246,8 @@ class Gql {
 
 			out += strings[i];
 		}
+		// Add fragment definitions
+		out += `\n${Object.values(fragments).join('\n')}`;
 		return out;
 	}
 

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -154,6 +154,7 @@ class Gql {
 
 	async exec(query, {
 		context,
+		ctx,
 		cache: {key: cacheKey, ttl = ONE_DAY} = {},
 		variables = {},
 		requestOptions = {},
@@ -169,7 +170,7 @@ class Gql {
 
 		const result = this._api ?
 			await this._execApi(query, {variables, requestOptions}) :
-			await this._execGraphql(query, {context, variables});
+			await this._execGraphql(query, {context: context || ctx, variables});
 
 		if (cacheKey && this._cache) await this._cache.set(cacheKey, result, {ttl});
 		return result;

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -206,7 +206,7 @@ class Gql {
 		if (!this._fragments) throw new Error('Invalid Method: Fragments not defined');
 		if (this._fragments[name] === undefined) throw new Error(`[schema:${this._schemaName}] Invalid fragment name, ${name}`);
 
-		return new GqlFragment(this._fragments, name);
+		return new GqlFragment(this._fragments[name]);
 	}
 
 	static toGqlArg = toGqlArg;

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -195,6 +195,8 @@ class Gql {
 	}
 
 	fragment(name) {
+		if (!this.fragments || this.fragments[name] === undefined) throw new Error(`[schema:${this.schemaName}] Invalid fragment name, ${name}`);
+
 		return new GqlFragment(this.fragments, name);
 	}
 

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -142,7 +142,7 @@ class Gql {
 		const errors = result.errors;
 
 		errors.forEach((error) => {
-			error = this.formatError(error);
+			error = this.formatError(error, context);
 			Object.assign(fields, error.fields);
 		});
 

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -114,7 +114,7 @@ class Gql {
 			throw err;
 		}
 
-		return result;
+		return result.data;
 	}
 
 	async _execGraphql(query, {context, variables = {}} = {}) {

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -2,7 +2,12 @@ import _ from 'lodash';
 import {parse, validate, execute} from 'graphql';
 import {Connect, Str} from 'sm-utils';
 
-import {formatError} from './errors';
+import {
+	formatError,
+	convertObjToGqlArg,
+	convertToGqlArg,
+	GqlEnum,
+} from './helpers';
 import {makeSchemaFromConfig} from './makeSchemaFrom';
 
 const ONE_DAY = 24 * 3600 * 1000;
@@ -10,10 +15,6 @@ const ONE_DAY = 24 * 3600 * 1000;
 class ApiError extends Error {}
 class GraphqlError extends Error {}
 
-class GqlEnum {
-	constructor(val) { this.val = val }
-	toString() { return this.val }
-}
 /**
  * we are not using the inbuilt graphql function because it validates
  * the graphql, which is an expensive operation
@@ -47,28 +48,6 @@ function graphql({
 		context,
 		variables,
 	);
-}
-
-function convertObjToGqlArg(obj) {
-	const gqlArg = [];
-	_.forEach(obj, (value, key) => {
-		// eslint-disable-next-line no-use-before-define
-		gqlArg.push(`${key}: ${convertToGqlArg(value)}`);
-	});
-	return `${gqlArg.join(', ')}`;
-}
-
-function convertToGqlArg(value) {
-	if (value == null) return null;
-
-	if (typeof value === 'number') return String(value);
-	if (value instanceof GqlEnum) return value.toString();
-	if (_.isPlainObject(value)) return `{${convertObjToGqlArg(value)}}`;
-	if (_.isArray(value) && value[0] instanceof GqlEnum) {
-		return `[${value.map(v => v.toString()).join(', ')}]`;
-	}
-
-	return JSON.stringify(value);
 }
 
 class Gql {

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -252,7 +252,8 @@ class Gql {
 
 			out += strings[i];
 		}
-		// Add fragment definitions
+		if (_.isEmpty(fragments)) return out;
+
 		out += `\n${Object.values(fragments).join('\n')}`;
 		return out;
 	}

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -204,7 +204,8 @@ class Gql {
 	}
 
 	fragment(name) {
-		if (!this._fragments || this._fragments[name] === undefined) throw new Error(`[schema:${this._schemaName}] Invalid fragment name, ${name}`);
+		if (!this._fragments) throw new Error('Invalid Method: Fragments not defined');
+		if (this._fragments[name] === undefined) throw new Error(`[schema:${this._schemaName}] Invalid fragment name, ${name}`);
 
 		return new GqlFragment(this._fragments, name);
 	}

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -80,9 +80,11 @@ class Gql {
 		this._cache = opts.cache;
 	}
 
-	async _execApi(query, {variables, requestOptions = {}} = {}) {
+	async _execApi(query, {variables = {}, requestOptions = {}} = {}) {
 		let response = Connect
 			.url(this._api.endpoint)
+			.headers(this._api.headers)
+			.cookies(this._api.cookies)
 			.headers(requestOptions.headers)
 			.cookies(requestOptions.cookies)
 			.body({query, variables})

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -4,8 +4,7 @@ import {Connect, Str} from 'sm-utils';
 
 import {
 	formatError,
-	convertObjToGqlArg,
-	convertToGqlArg,
+	toGqlArg,
 	GqlEnum,
 	GqlFragment,
 } from './helpers';
@@ -210,24 +209,7 @@ class Gql {
 		return new GqlFragment(this._fragments, name);
 	}
 
-	static toGqlArg(arg, opts = {}) {
-		let gqlArg = '';
-		if (_.isPlainObject(arg)) {
-			if (Array.isArray(opts)) opts = {pick: opts};
-			if (opts.pick) arg = _.pick(arg, opts.pick);
-
-			gqlArg = convertObjToGqlArg(arg);
-
-			if (opts.curlyBrackets) gqlArg = `{${gqlArg}}`;
-		}
-		else {
-			gqlArg = convertToGqlArg(arg);
-		}
-
-		if (opts.roundBrackets) gqlArg = gqlArg ? `(${gqlArg})` : ' ';
-
-		return gqlArg || '# no args <>\n';
-	}
+	static toGqlArg = toGqlArg;
 
 	static tag(strings, ...args) {
 		let out = strings[0];

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -7,6 +7,7 @@ import {
 	convertObjToGqlArg,
 	convertToGqlArg,
 	GqlEnum,
+	GqlFragment,
 } from './helpers';
 import {makeSchemaFromConfig} from './makeSchemaFrom';
 
@@ -64,10 +65,11 @@ class Gql {
 			const schemaName = opts.schemaName !== undefined ?
 				opts.schemaName :
 				(opts.defaultSchemaName || 'default');
-			const {schema, pubsub} = makeSchemaFromConfig(opts);
+			const {schema, pubsub, fragments} = makeSchemaFromConfig(opts);
 
 			this.schemaName = schemaName;
 			this.schema = schema[schemaName];
+			this.fragments = fragments[schemaName];
 			this.pubsub = pubsub;
 			this.validateGraphql = opts.validateGraphql || false;
 			this.formatError = opts.formatError || formatError;
@@ -192,6 +194,10 @@ class Gql {
 		return this.constructor.enum(val);
 	}
 
+	fragment(name) {
+		return new GqlFragment(this.fragments, name);
+	}
+
 	static toGqlArg(arg, opts = {}) {
 		let gqlArg = '';
 		if (_.isPlainObject(arg)) {
@@ -223,6 +229,9 @@ class Gql {
 				// arg is a graphql field
 				if (typeof arg === 'string') {
 					out += arg;
+				}
+				else if (arg instanceof GqlFragment) {
+					out += arg.toString();
 				}
 				else if (Array.isArray(arg)) {
 					out += arg.filter(Boolean).join(' ');

--- a/src/Gql.js
+++ b/src/Gql.js
@@ -98,6 +98,7 @@ class Gql {
 			const err = new ApiError(`${response.statusCode}, Invalid status code`);
 			err.errors = result && result.errors;
 			err.body = response.body;
+			err.statusCode = response.statusCode;
 			throw err;
 		}
 

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -23,7 +23,7 @@ import {withFilter} from 'graphql-subscriptions';
 import defaultScalars from './defaultScalars';
 import defaultTypes from './defaultTypes';
 import defaultArgs from './defaultArgs';
-import {convertObjToGqlArg, convertToGqlArg} from './helpers';
+import {toGqlArg} from './helpers';
 
 function identity(value) {
 	return value;
@@ -605,10 +605,7 @@ class Schema {
 			str += field.name;
 
 			if (field.args) {
-				str += ' ( ';
-				if (_.isPlainObject(field.args)) str += convertObjToGqlArg(field.args);
-				else str += convertToGqlArg(field.args);
-				str += ' ) ';
+				str += toGqlArg(field.args, {roundBrackets: true});
 			}
 
 			if (field.fields) {

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -615,7 +615,7 @@ class Schema {
 			return str;
 		}).join('\n');
 
-		return `{ ${fieldsString} }`;
+		return `${fieldsString}`;
 	}
 
 	parseGraphqlEnumValue(schema, value, name) {
@@ -760,7 +760,11 @@ class Schema {
 	parseGraphqlFragment(schema, fragment) {
 		const type = this.getTypeName(fragment.type);
 		if (!schema.types[type]) throw new Error(`Type for fragment does not exist, ${type}`);
-		return `... ${fragment.name} on ${type}	${this.parseFragmentFields(fragment.fields)}`;
+		return {
+			name: fragment.name,
+			type,
+			fields: this.parseFragmentFields(fragment.fields),
+		};
 	}
 
 	parseGraphqlScalars(schema, scalars) {

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -603,14 +603,16 @@ class Schema {
 			let str = '';
 			if (field.alias) { str += `${field.alias} : ` }
 			str += field.name;
+
 			if (field.args) {
 				str += ' ( ';
 				if (_.isPlainObject(field.args)) str += convertObjToGqlArg(field.args);
 				else str += convertToGqlArg(field.args);
 				str += ' ) ';
 			}
+
 			if (field.fields) {
-				str += this.parseFragmentFields(field.fields);
+				str += `{ ${this.parseFragmentFields(field.fields)} }`;
 			}
 			return str;
 		}).join('\n');

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -38,7 +38,7 @@ function mergeFields(field1, field2) {
 	if (typeof field1 === 'string') field1 = {type: field1};
 	if (typeof field2 === 'string') field2 = {type: field2};
 
-	return Object.assign(field1, field2);
+	return Object.assign({}, field1, field2);
 }
 
 class Schema {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -132,6 +132,11 @@ class GqlEnum {
 	toString() { return this.val }
 }
 
+class GqlFragment {
+	constructor(fragments, key) { this.val = fragments[key] }
+	toString() { return this.val }
+}
+
 function convertObjToGqlArg(obj) {
 	const gqlArg = [];
 	_.forEach(obj, (value, key) => {
@@ -160,4 +165,5 @@ export {
 	convertObjToGqlArg,
 	convertToGqlArg,
 	GqlEnum,
+	GqlFragment,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -134,7 +134,11 @@ class GqlEnum {
 
 class GqlFragment {
 	constructor(fragments, key) { this.val = fragments[key] }
-	toString() { return this.val }
+	toString() { return `... ${this.val.name}` }
+	getName() { return this.val.name }
+	getDefinition() {
+		return `fragment ${this.val.name} on ${this.val.type} { ${this.val.fields} } `;
+	}
 }
 
 function convertObjToGqlArg(obj) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -133,7 +133,7 @@ class GqlEnum {
 }
 
 class GqlFragment {
-	constructor(fragments, key) { this.val = fragments[key] }
+	constructor(fragment) { this.val = fragment }
 	toString() { return `... ${this.val.name}` }
 	getName() { return this.val.name }
 	getDefinition() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -163,11 +163,31 @@ function convertToGqlArg(value) {
 	return JSON.stringify(value);
 }
 
+function toGqlArg(arg, opts = {}) {
+	let gqlArg = '';
+	if (_.isPlainObject(arg)) {
+		if (Array.isArray(opts)) opts = {pick: opts};
+		if (opts.pick) arg = _.pick(arg, opts.pick);
+
+		gqlArg = convertObjToGqlArg(arg);
+
+		if (opts.curlyBrackets) gqlArg = `{${gqlArg}}`;
+	}
+	else {
+		gqlArg = convertToGqlArg(arg);
+	}
+
+	if (opts.roundBrackets) gqlArg = gqlArg ? `(${gqlArg})` : ' ';
+
+	return gqlArg || '# no args <>\n';
+}
+
 export {
 	formatError,
 	humanizeError,
 	convertObjToGqlArg,
 	convertToGqlArg,
+	toGqlArg,
 	GqlEnum,
 	GqlFragment,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -127,7 +127,37 @@ function formatError(error) {
 	return error;
 }
 
+class GqlEnum {
+	constructor(val) { this.val = val }
+	toString() { return this.val }
+}
+
+function convertObjToGqlArg(obj) {
+	const gqlArg = [];
+	_.forEach(obj, (value, key) => {
+		// eslint-disable-next-line no-use-before-define
+		gqlArg.push(`${key}: ${convertToGqlArg(value)}`);
+	});
+	return `${gqlArg.join(', ')}`;
+}
+
+function convertToGqlArg(value) {
+	if (value == null) return null;
+
+	if (typeof value === 'number') return String(value);
+	if (value instanceof GqlEnum) return value.toString();
+	if (_.isPlainObject(value)) return `{${convertObjToGqlArg(value)}}`;
+	if (_.isArray(value) && value[0] instanceof GqlEnum) {
+		return `[${value.map(v => v.toString()).join(', ')}]`;
+	}
+
+	return JSON.stringify(value);
+}
+
 export {
 	formatError,
 	humanizeError,
+	convertObjToGqlArg,
+	convertToGqlArg,
+	GqlEnum,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ async function generateTypesFromSchema(graphqlSchemas, {contextType = 'any', out
 	}));
 }
 
-export * from './errors';
+export * from './helpers';
 export * from './connection';
 export * from './Schema';
 export * from './makeSchemaFrom';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import _ from 'lodash';
+import {File} from 'sm-utils';
 
 async function generateTypesFromSchema(graphqlSchemas, {contextType = 'any', outputPath, schema, options = {}} = {}) {
 	let generateTypeScriptTypes;
@@ -16,6 +17,16 @@ async function generateTypesFromSchema(graphqlSchemas, {contextType = 'any', out
 
 	schema = _.castArray(schema);
 
+	const getTypeStringForFragments = (fragments, schemaName) => `\
+
+
+declare global {
+	namespace GraphQl.${schemaName} {
+		type fragments = '${Object.keys(fragments).join("' | '")}';
+	}
+}
+`;
+
 	return Promise.all(Object.keys(graphqlSchemas).map(async (schemaName) => {
 		if (schema.length && !schema.includes(schemaName)) return;
 
@@ -26,14 +37,23 @@ async function generateTypesFromSchema(graphqlSchemas, {contextType = 'any', out
 			// https://github.com/dangcuuson/graphql-schema-typescript/issues/17
 			// asyncResult: true
 		};
+		const graphqlSchema = graphqlSchemas[schemaName];
+		const fragments = graphqlSchema._fragments;
+
+		const typesFile = new File(path.join(folder, `${schemaName}.d.ts`));
+
 		await generateTypeScriptTypes(
-			graphqlSchemas[schemaName],
-			path.join(folder, `${schemaName}.d.ts`),
+			graphqlSchema,
+			typesFile.path,
 			_.merge(defaultOptions, options, {
 				namespace: `GraphQl.${schemaName}`,
 				contextType,
 			}),
 		);
+
+		if (_.isEmpty(fragments)) return;
+
+		await typesFile.append(getTypeStringForFragments(fragments, schemaName));
 	}));
 }
 

--- a/src/makeSchemaFrom.js
+++ b/src/makeSchemaFrom.js
@@ -33,6 +33,7 @@ function makeSchemaFromObjects(schemas, resolvers, opts = {}) {
 		schema: graphqlSchemas,
 		defaultSchema: graphqlSchemas[defaultSchemaName],
 		pubsub,
+		fragments: _.mapValues(graphqlSchemas, schema => schema._fragments),
 	};
 }
 


### PR DESCRIPTION
Closes #17 

- Also fixes a bug where interfaces were being mutated (25c7ccd)
- Move `schemaName` option from `exec` to constructor because fragments are bound to schemas

