### PR TITLE
Interface extends interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,13 @@ const Vehicle = {
 	// if schema is not given, it won't be available in any schema
 	schema: ['admin', 'public'],
 
+	// extends (optional): extend other interfaces(s)
+	// Fields of other interfaces will be merged in this interface.
+	// (To expose all common fields in graphql api)
+	// If some interface(s) do(es) not belong to the currently used schema
+	// then that interface(s) will be ignored.
+	extends: ['Transport'],
+
 	// fields (required): fields of the interface
 	// see Fields definition for more details
 	fields: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,9 +131,11 @@ declare module 'gqutils' {
 
 	interface GQUtilsInterfaceSchema extends GQUtilsBaseSchema {
 		graphql: 'interface';
-		/**
-		 * fields of the interface
-		 */
+
+		/** Extend other interface(s) */
+		extends?: string[];
+
+		/** fields of the interface */
 		fields: GQUtilsFields;
 
 		/** resolveType (optional): function for determining which type is actually used when the value is resolved */

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -69,6 +69,7 @@ function collectDependenciesUtil(schema, allInterfaces, interfaceName, state = {
 	const _interface = schema.interfaces[interfaceName];
 
 	if (_interface === undefined) {
+		// Ignore interface if it is defined in other schema
 		if (allInterfaces.includes(interfaceName)) return [];
 		throw new Error(`Interface "${interfaceName}" is not defined`);
 	}

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -740,6 +740,10 @@ class Schema {
 		const dependencies = this.collectSingleInterfaceDependencies(schema, schemaItem.name);
 
 		const fields = {};
+
+		// Reverse iteration is done to merge fields according to hierarchy
+		// For ex. if B extends A then to get B's fields, merge B's fields into A's not the other way.
+		// Hence overrided fields will not be affected
 		for (let i = dependencies.length - 1; i >= 0; i--) {
 			const _interface = schema.interfaces[dependencies[i]];
 			Object.assign(fields, _interface.fields);

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -433,8 +433,8 @@ class Schema {
 	}
 
 	collectSingleInterfaceDependencies(schema, interfaceName) {
-		let interfaces = this.schemas[this.defaultSchemaName].interfaces;
-		interfaces = interfaces.map(i => i.name);
+		let allInterfaces = this.schemas[this.defaultSchemaName].interfaces;
+		allInterfaces = _.map(allInterfaces, i => i.name);
 
 		const dependencies = [];
 		const processQueue = [interfaceName];
@@ -444,7 +444,7 @@ class Schema {
 			const _interface = schema.interfaces[top];
 
 			if (_interface === undefined) {
-				if (interfaces.includes(top)) continue;
+				if (allInterfaces.includes(top)) continue;
 				throw new Error(`Interface "${top}" is not defined`);
 			}
 			if (dependencies.includes(top)) throw new Error(`Cyclic dependency in interface "${interfaceName}"`);

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -444,8 +444,8 @@ class Schema {
 			const _interface = schema.interfaces[top];
 
 			if (_interface === undefined) {
-				if (interfaces.includes(_interface)) continue;
-				throw new Error(`Interface ${_interface} is not defined`);
+				if (interfaces.includes(top)) continue;
+				throw new Error(`Interface "${top}" is not defined`);
 			}
 			if (dependencies.includes(top)) throw new Error(`Cyclic dependency in interface "${interfaceName}"`);
 


### PR DESCRIPTION
- fixes #24 
- Extend interfaces by defining `extends` property in the interface.
  Ex.  
	```js
	const InterfaceB = {
		graphql: 'interface',
		...
	}

	const InterfaceA = {
		graphql: 'interface',
		extends: ['InterfaceB'],
		...
	}
	```