### PR TITLE
Improve GqlFragment parser, add separate methods for query parsing and executing parsed queries

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import {PubSub} from 'graphql-subscriptions';
-import {GraphQLSchema} from 'graphql';
+import {GraphQLSchema, DocumentNode} from 'graphql';
 import {IResolverValidationOptions} from 'graphql-tools';
 import {GenerateTypescriptOptions} from 'graphql-schema-typescript';
 import graphqlListFields = require('graphql-list-fields');
@@ -376,7 +376,7 @@ declare module 'gqutils' {
 		 * @param error Error object
 		 * @param context The context passed to exec
 		 */
-		formatError?: (error: Error, context: any) => any;
+		formatError?: (error: Error, context?: any) => any;
 	}
 
 
@@ -424,6 +424,9 @@ declare module 'gqutils' {
 
 		abstract _getQueryResult(query: string, opts: Omit<ExecOptions, 'cache'>): Promise<any>;
 
+		/**
+		 * Returns the `data` key if no errors, else throws a formatted error instance
+		 */
 		exec(query: string, opts?: ExecOptions): Promise<any>;
 		getAll(query: string, opts?: ExecOptions): Promise<any>;
 		get(query: string, opts: ExecOptions): Promise<any>;
@@ -471,6 +474,13 @@ declare module 'gqutils' {
 		getSchemas(): schemaMap;
 		getPubSub(): PubSub;
 		getData(): {[schemaName: string]: GQUtilsData};
+
+		parse(query: string): DocumentNode;
+
+		/**
+		 * Returns the `data` key if no errors, else throws a formatted error instance
+		 */
+		execParsed(document: DocumentNode, opts: Omit<ExecOptions, 'cache' | 'requestOptions'>): Promise<any>;
 
 		_getQueryResult(query: string, opts: Omit<ExecOptions, 'cache' | 'requestOptions'>): Promise<any>;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -475,12 +475,17 @@ declare module 'gqutils' {
 		getPubSub(): PubSub;
 		getData(): {[schemaName: string]: GQUtilsData};
 
-		parse(query: string, opts?: {validate?: boolean}): DocumentNode;
+		/**
+		 * Pre parse a query and cache it for faster executions
+		 * @param query Query string
+		 * @param opts Provide meta option to tag the result so it can be identified later
+		 */
+		parse<T extends string>(query: string, opts?: {validate?: boolean, meta?: T}): DocumentNode & {__meta: T};
 
 		/**
 		 * Returns the `data` key if no errors, else throws a formatted error instance
 		 */
-		execParsed(document: DocumentNode, opts: Omit<ExecOptions, 'cache' | 'requestOptions'>): Promise<any>;
+		execParsed(document: DocumentNode & {__meta?: string}, opts: Omit<ExecOptions, 'cache' | 'requestOptions'>): Promise<any>;
 
 		_getQueryResult(query: string, opts: Omit<ExecOptions, 'cache' | 'requestOptions'>): Promise<any>;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -201,6 +201,7 @@ declare module 'gqutils' {
 	type fragmentField = string | Array<string | FragmentFieldObj>
 
 	interface FragmentFieldObj {
+		/** This is the `type` if `inline` is true */
 		name: string;
 		/** If you want to alias the field, like: `name: fullName` */
 		alias?: string;
@@ -208,6 +209,8 @@ declare module 'gqutils' {
 		args?: {[arg: string]: any};
 		/** If field type is itself aan object type */
 		fields?: fragmentField;
+		/** If this is an inline fragment, in that case `name` is considered the type of the inline fragment */
+		inline?:  boolean;
 	}
 
 	interface GQUtilsFragmentSchema extends GQUtilsBaseSchema {

--- a/index.d.ts
+++ b/index.d.ts
@@ -475,7 +475,7 @@ declare module 'gqutils' {
 		getPubSub(): PubSub;
 		getData(): {[schemaName: string]: GQUtilsData};
 
-		parse(query: string): DocumentNode;
+		parse(query: string, opts?: {validate?: boolean}): DocumentNode;
 
 		/**
 		 * Returns the `data` key if no errors, else throws a formatted error instance

--- a/src/GqlSchema.js
+++ b/src/GqlSchema.js
@@ -71,9 +71,9 @@ class GqlSchema extends Gql {
 	/**
 	 * Pre parse queries that don;t have any static data and use variables
 	 * @param {string} query
-	 * @param {any} [context]
+	 * @param {{context: any, validate?: boolean, meta?: string}} opts
 	 */
-	parse(query, {context, validate: validateGraphql = this._validateGraphql} = {}) {
+	parse(query, {context, validate: validateGraphql = this._validateGraphql, meta} = {}) {
 		let document;
 		try {
 			document = graphqlParse(query);
@@ -87,6 +87,9 @@ class GqlSchema extends Gql {
 			if (validationErrors.length > 0) {
 				return this._formatAndThrowErrors(validationErrors, context);
 			}
+		}
+		if (meta) {
+			document.__meta = meta;
 		}
 		return document;
 	}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -220,8 +220,11 @@ function parseFragmentFields(fields) {
 	const fieldsString = castArray(fields).map((field) => {
 		if (typeof field === 'string') return field;
 		let str = '';
-		if (field.alias) { str += `${field.alias} : ` }
-		str += field.name;
+		if (field.inline) { str += `... on ${field.name} ` }
+		else {
+			if (field.alias) { str += `${field.alias} : ` }
+			str += field.name;
+		}
 
 		if (field.args) {
 			str += toGqlArg(field.args, {roundBrackets: true});


### PR DESCRIPTION
### Add support for inline fragments in GqlFragment parser

For fragments like:

```gql
fragment ItemFragment on Item {
  title
  ... on InlineType {
		name
   }
}
```

These can now be defined by:
```js
const ItemFragment = {
	graphql: 'fragment',
	schema: ['admin'],
	type: 'Item',
	fields: [
		'title',
		{
			name: 'InlineType',
			inline: true,
			fields: [
				'name',
			],
		},
	],
};
```

### Add `parse` and `execParsed` methods to `GqlSchema`

This will allow us to cache pre parsed queries. Also validate them in a test suite.

